### PR TITLE
Fixes the use of the blogDir variable when wanting to hide content

### DIFF
--- a/layouts/partials/archive.html
+++ b/layouts/partials/archive.html
@@ -4,7 +4,7 @@
   {{ $pages = .Site.RegularPages }}
 {{ end }}
 {{ with .Site.Params.blogDir }}
-  {{ $pages = where $.Site.RegularPages "Section" "blog" }}
+  {{ $pages = where $.Site.RegularPages "Section" . }}
 {{ end }}
 <ul class='posts wrap' id = 'posts'>
   {{- range (.Paginate $pages).Pages }}


### PR DESCRIPTION
This fix amends the previous version of the archives partial, such that the value of the `blogDir` config item is used correctly for filtering page types.

For example:

Setting the `blogDir` value in the config.toml to something like:

```toml
blogDir = "posts"
```
will not actually cause the partial to render correctly, as the code within it looks like this:

```html
{{ with .Site.Params.blogDir }}
  {{ $pages = where $.Site.RegularPages "Section" "blog" }}
{{ end }}
```
Regardless of what the value of `blogDir` is set to, the partial will always look in the "blog" directory for items.

The change for this is simple:

```html
{{ with .Site.Params.blogDir }}
  {{ $pages = where $.Site.RegularPages "Section" . }}
{{ end }}
```
The `.` character here says "use the value of `.Site.Params.blogDir`, which tells Hugo to filter based on Regular Pages which are found in the section named the same as the value of `blogDir`.

This will allow consumers to use whatever directory they wish, rather than the hardcoded "blog" value